### PR TITLE
feat: 상품 내역 조회(삭제된 상품 제외)

### DIFF
--- a/src/main/java/com/unknown/commerceserver/domain/item/api/ItemController.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/api/ItemController.java
@@ -1,0 +1,29 @@
+package com.unknown.commerceserver.domain.item.api;
+
+import com.unknown.commerceserver.domain.item.application.ItemService;
+import com.unknown.commerceserver.domain.item.dto.response.ItemResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/items")
+@Tag(name = "v1-items", description = "상품 관련 API")
+public class ItemController {
+    private final ItemService itemService;
+
+    @Operation(summary = "상품 내역 조회", description = "삭제된 상품 제외 모든 상품 내역 조회")
+    @GetMapping
+    public ResponseEntity<List<ItemResponse>> getAllItems() {
+        List<ItemResponse> allItems = itemService.getAllItems();
+
+        return ResponseEntity.ok().body(allItems);
+    }
+}

--- a/src/main/java/com/unknown/commerceserver/domain/item/application/ItemService.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/application/ItemService.java
@@ -1,0 +1,11 @@
+package com.unknown.commerceserver.domain.item.application;
+
+import com.unknown.commerceserver.domain.item.dto.response.ItemResponse;
+
+import java.util.List;
+
+public interface ItemService {
+
+    // 상품 내역 조회
+    List<ItemResponse> getAllItems();
+}

--- a/src/main/java/com/unknown/commerceserver/domain/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/application/ItemServiceImpl.java
@@ -1,0 +1,31 @@
+package com.unknown.commerceserver.domain.item.application;
+
+import com.unknown.commerceserver.domain.item.dao.ItemRepository;
+import com.unknown.commerceserver.domain.item.dto.response.ItemResponse;
+import com.unknown.commerceserver.domain.item.entity.Item;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemServiceImpl implements ItemService {
+    private final ItemRepository itemRepository;
+
+    // 상품 내역 조회
+    @Override
+    public List<ItemResponse> getAllItems() {
+        // TODO 삭제되지 않은 제품, 제품에 수량이 있는 경우 보여줄 것
+//        List<Item> items = itemRepository.findAll();
+        // QueryDSL 써야 겠는데
+        List<Item> items = itemRepository.findAllAndDeletedAtIsNull();
+
+        List<ItemResponse> itemResponses = items.stream()
+                .map(item -> ItemResponse.of(item)).toList();
+
+        return itemResponses;
+    }
+}

--- a/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepository.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
     Optional<Item> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepositoryCustom.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.unknown.commerceserver.domain.item.dao;
+
+import com.unknown.commerceserver.domain.item.entity.Item;
+
+import java.util.List;
+
+public interface ItemRepositoryCustom {
+    List<Item> findAllAndDeletedAtIsNull();
+}

--- a/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepositoryImpl.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.unknown.commerceserver.domain.item.dao;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.unknown.commerceserver.domain.item.entity.Item;
+import com.unknown.commerceserver.domain.item.entity.QItem;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ItemRepositoryImpl implements ItemRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QItem qItem = QItem.item;
+
+    @Override
+    public List<Item> findAllAndDeletedAtIsNull() {
+        // 삭제되지 않은 제품, TODO 제품에 수량이 있는 경우 보여줄 것
+        BooleanBuilder where = new BooleanBuilder();
+
+        where.and(qItem.deletedAt.isNull());
+
+        List<Item> items = jpaQueryFactory
+                .select(qItem)
+                .from(qItem)
+                .where(where)
+                .fetch();
+
+        return items;
+    }
+}

--- a/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepositoryImpl.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/dao/ItemRepositoryImpl.java
@@ -16,6 +16,7 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
 
     @Override
     public List<Item> findAllAndDeletedAtIsNull() {
+        // TODO 정렬 고민, type에 따라 선택 가능 고민
         // 삭제되지 않은 제품, TODO 제품에 수량이 있는 경우 보여줄 것
         BooleanBuilder where = new BooleanBuilder();
 

--- a/src/main/java/com/unknown/commerceserver/domain/item/dto/response/ItemResponse.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/dto/response/ItemResponse.java
@@ -1,0 +1,39 @@
+package com.unknown.commerceserver.domain.item.dto.response;
+
+import com.unknown.commerceserver.domain.item.entity.Item;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Schema(description = "상품 내역 정보")
+public class ItemResponse {
+    @Schema(description = "상품 테이블 고유 번호")
+    private Long id;
+
+    @Schema(description = "상품 타입 : 의류, 식품 등등")
+    private String type;
+
+    @Schema(description = "상품 이름")
+    private String name;
+
+    @Schema(description = "상품 가격")
+    private BigDecimal price;
+
+    @Schema(description = "상품 정보")
+    private String info;
+
+    public static ItemResponse of(Item item) {
+        return ItemResponse.builder()
+                .id(item.getId())
+                .type(item.getType())
+                .name(item.getName())
+                .price(item.getPrice())
+                .info(item.getInfo())
+                .build();
+    }
+}

--- a/src/main/java/com/unknown/commerceserver/global/config/QueryDSLConfiguration.java
+++ b/src/main/java/com/unknown/commerceserver/global/config/QueryDSLConfiguration.java
@@ -4,10 +4,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * QueryDSL 컨피그 파일 생성
  */
+@Configuration
 public class QueryDSLConfiguration {
     @PersistenceContext
     private EntityManager entityManager;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     password: ON_SECRET
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 구현해야 하는 API
- 3개 중 한 개 완료
- [ ] 1. 주문 완료
- [x] 2. 상품 내역 조회
- [ ] 3. 상품 상세 조회

<br>

- 상품 내역 조회에서 나중에 추가해 볼 사항
  - 상품 type 별로 검색 가능
  - 제품의 수량이 1이상인 경우만 보여줄 수 있게 하기 - 수량이 부족할 경우 조회 안됨
  - 정렬 고민 (상품 등록순, 가나다순 등등)