### PR TITLE
feat: product에 Pessimistic Lock 적용을 위해 코드 수정 및 queryDSL 적용

### DIFF
--- a/src/main/java/com/unknown/commerceserver/domain/item/dto/request/ItemRequest.java
+++ b/src/main/java/com/unknown/commerceserver/domain/item/dto/request/ItemRequest.java
@@ -1,7 +1,10 @@
 package com.unknown.commerceserver.domain.item.dto.request;
 
+import com.unknown.commerceserver.domain.order.dto.request.ProductRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,4 +17,7 @@ public class ItemRequest {
 
     @Schema(description = "주문한 상품 수량")
     private Long quantity;
+
+    @Schema(description = "상품의 제품들")
+    private List<ProductRequest> productRequests;
 }

--- a/src/main/java/com/unknown/commerceserver/domain/order/dto/request/ProductRequest.java
+++ b/src/main/java/com/unknown/commerceserver/domain/order/dto/request/ProductRequest.java
@@ -1,0 +1,14 @@
+package com.unknown.commerceserver.domain.order.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Schema(description = "상품의 제품 내역 정보")
+public class ProductRequest {
+    @Schema(description = "제품 테이블 고유 번호")
+    private Long id;
+}

--- a/src/main/java/com/unknown/commerceserver/domain/product/dao/ProductRepository.java
+++ b/src/main/java/com/unknown/commerceserver/domain/product/dao/ProductRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
     Optional<Product> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/unknown/commerceserver/domain/product/dao/ProductRepositoryCustom.java
+++ b/src/main/java/com/unknown/commerceserver/domain/product/dao/ProductRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.unknown.commerceserver.domain.product.dao;
+
+import com.unknown.commerceserver.domain.product.entity.Product;
+
+import java.util.Optional;
+
+public interface ProductRepositoryCustom {
+    Optional<Product> findByIdAndDeletedAtIsNullForUpdate(Long id);
+}

--- a/src/main/java/com/unknown/commerceserver/domain/product/dao/ProductRepositoryImpl.java
+++ b/src/main/java/com/unknown/commerceserver/domain/product/dao/ProductRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.unknown.commerceserver.domain.product.dao;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.unknown.commerceserver.domain.product.entity.Product;
+import com.unknown.commerceserver.domain.product.entity.QProduct;
+import jakarta.persistence.LockModeType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QProduct qProduct = QProduct.product;
+
+    @Override
+    public Optional<Product> findByIdAndDeletedAtIsNullForUpdate(Long productId) {
+        BooleanBuilder where = new BooleanBuilder();
+
+        where.and(qProduct.id.eq(productId))
+                .and(qProduct.deletedAt.isNull());
+
+        return Optional.ofNullable(jpaQueryFactory
+                .select(qProduct)
+                .from(qProduct)
+                .where(where)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne());
+    }
+}

--- a/src/main/java/com/unknown/commerceserver/domain/product/entity/Product.java
+++ b/src/main/java/com/unknown/commerceserver/domain/product/entity/Product.java
@@ -41,6 +41,6 @@ public class Product extends BaseEntity {
     private List<ItemProduct> itemProducts = new ArrayList<>();
 
     public void minusQuantity(Long quantity) {
-        this.quantity = this.quantity - quantity;
+        this.quantity -= quantity;
     }
 }

--- a/src/test/java/com/unknown/commerceserver/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/unknown/commerceserver/domain/order/application/OrderServiceTest.java
@@ -7,6 +7,7 @@ import com.unknown.commerceserver.domain.item.entity.Item;
 import com.unknown.commerceserver.domain.item.entity.ItemProduct;
 import com.unknown.commerceserver.domain.order.dao.OrderRepository;
 import com.unknown.commerceserver.domain.order.dto.request.OrderRequest;
+import com.unknown.commerceserver.domain.order.dto.request.ProductRequest;
 import com.unknown.commerceserver.domain.product.dao.ProductRepository;
 import com.unknown.commerceserver.domain.product.entity.Product;
 import org.junit.jupiter.api.AfterEach;
@@ -91,10 +92,16 @@ class OrderServiceTest {
         CountDownLatch latch = new CountDownLatch(threadCount);
 
         // 주문에 필요한 데이터 생성
+        // 상품에 포함되는 제품번호
+        ProductRequest productRequest = ProductRequest.builder()
+                .id(1L)
+                .build();
+
         // 주문할 상품 정보와 주문할 상품 수량
         ItemRequest itemRequest = ItemRequest.builder()
                 .id(1L)
                 .quantity(1L)
+                .productRequests(List.of(productRequest))
                 .build();
 
         // 주문 정보


### PR DESCRIPTION
- product에 Pessimistic Lock 적용을 위해 코드 수정 및 queryDSL 적용
- OrderRequest에서 상품에 관련된 제품 id 받음
- queryDSL 로 product를 조회하고 .setLockMode(LockModeType.PESSIMISTIC_WRITE) 를 추가함
- product 조회만 Pessimistic Lock 하고 싶었는데 
현재 나의 createOrder 로직의 트랜잭션 시작이 item 조회부터 시작이라서 itme 조회에도 Pessimistic Lock을 적용함